### PR TITLE
compatible old api

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.PropertiesUtil.getLong;
  *
  * <p>Please refer to Kafka's documentation for the available configuration properties:
  * http://kafka.apache.org/documentation.html#newconsumerconfigs
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
@@ -89,6 +89,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * AbstractFetcher}.
  *
  * @param <T> The type of records produced by this data source
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 
 /**
  * This Handler contains the topic offsets of upstream job id, epicNo, topic.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogEpicStateHandler implements Serializable {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read;
 
 import com.netease.arctic.flink.read.internals.AbstractFetcher;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.ReadableConfig;
@@ -47,6 +48,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
 
 /**
  * An arctic log consumer that consume arctic log data from kafka.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0; use {@link LogKafkaSource} instead.
  */
 @Deprecated
 public class LogKafkaConsumer extends FlinkKafkaConsumer<RowData> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
@@ -36,6 +36,8 @@ import java.util.Properties;
 /**
  * This thread is an extent of {@link KafkaConsumerThread} added an abstract method
  * {@link KafkaConsumerThread#reSeekPartitionOffsets()} to reSeek the offset of kafka topic partitions.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaConsumerThread<T> extends KafkaConsumerThread<T> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
@@ -56,6 +56,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The fetcher runs in {@link LogKafkaConsumer} and fetches messages from kafka, and retracts message as handling a
  * Flip message that {@link LogData#getFlip()} is true.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaFetcher extends KafkaFetcher<RowData> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
@@ -46,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * According to upstreamId and partition topic dealing with the flip message, when should begin to retract message and
  * when to end it.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
+ * use {@link com.netease.arctic.flink.read.source.log.LogSourceHelper} instead.
  */
 @Deprecated
 public class LogReadHelper implements Serializable {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of elements deserialized from Kafka's byte records, and emitted into the
  *            Flink data streams.
  * @param <K> The type of topic/partition identifier used by Kafka in the specific version.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Implementation Note: This code is written to be reusable in later versions of the
  * KafkaConsumer. Because Kafka is not maintaining binary compatibility, we use a "call bridge" as
  * an indirection to the KafkaConsumer calls that change signature.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
@@ -52,6 +52,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * A fetcher that fetches data from Kafka brokers via the Kafka consumer API.
  *
  * @param <T> The type of elements produced by the fetcher.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -59,7 +59,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
  *    .build();
  * }</pre>
  *
- * <p>See {@link KafkaSourceBuilder} for more details.
+ * <p>See {@link LogKafkaSourceBuilder} for more details.
  */
 public class LogKafkaSource extends KafkaSource<RowData> {
   private static final long serialVersionUID = 1L;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -32,7 +32,9 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -46,6 +48,7 @@ import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -64,20 +67,26 @@ import java.util.Set;
 import static com.netease.arctic.flink.FlinkSchemaUtil.getPhysicalSchema;
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL;
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL_OPTION;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PROPS_GROUP_ID;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOPIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getKafkaProperties;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopicPattern;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopics;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateSourceTopic;
@@ -228,12 +237,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     return options;
   }
 
-  private LogDynamicSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
+  private ScanTableSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
-    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-    
+
     validateSourceTopic(tableOptions);
 
     final Properties properties = getLogStoreProperties(arcticTable.properties());
@@ -249,8 +257,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         catalogTable.getSchema().toPhysicalRowDataType();
 
     final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
-    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat = getValueDecodingFormat(helper);
-    
+
     String startupMode = tableOptions.get(SCAN_STARTUP_MODE);
     long startupTimestampMillis = 0L;
     if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
@@ -260,9 +267,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
+    if (useOldAPI(arcticTable)) {
+      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+          startupTimestampMillis, arcticTable, schema);
+    }
     return new LogDynamicSource(
-        physicalDataType,
-        valueDecodingFormat,
         valueProjection,
         getSourceTopics(tableOptions),
         getSourceTopicPattern(tableOptions),
@@ -272,6 +281,82 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         schema,
         tableOptions,
         arcticTable);
+  }
+
+  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+                                                    int[] valueProjection,
+                                                    Properties properties,
+                                                    Context context,
+                                                    ReadableConfig tableOptions,
+                                                    long startupTimestampMillis,
+                                                    ArcticTable arcticTable,
+                                                    Schema schema) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        getKeyDecodingFormat(helper);
+    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat = getValueDecodingFormat(helper);
+
+    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+    String startupMode = tableOptions.get(SCAN_STARTUP_MODE);
+
+    LOG.info("create log source with deprecated API");
+    return new KafkaDynamicSource(
+        physicalDataType,
+        keyDecodingFormat.orElse(null),
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        KafkaOptions.getSourceTopics(tableOptions),
+        KafkaOptions.getSourceTopicPattern(tableOptions),
+        properties,
+        startupMode,
+        startupTimestampMillis,
+        false,
+        schema,
+        tableOptions,
+        arcticTable.name());
+  }
+
+  private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, KEY_FORMAT);
+    keyDecodingFormat.ifPresent(
+        format -> {
+          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            throw new ValidationException(
+                String.format(
+                    "A key format should only deal with INSERT-only records. " +
+                        "But %s has a changelog mode of %s.",
+                    helper.getOptions().get(KEY_FORMAT),
+                    format.getChangelogMode()));
+          }
+        });
+    return keyDecodingFormat;
+  }
+
+  /**
+   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
+   * {@link LOG_STORE_TYPE} is kafka.
+   */
+  private static boolean useOldAPI(ArcticTable arcticTable) {
+    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
+    if (useOldAPI) {
+      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
+      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
+        LOG.warn("{} option only take effect for {} = {}.",
+            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+        return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -18,31 +18,41 @@
 
 package com.netease.arctic.flink.table;
 
+import com.netease.arctic.flink.read.FlinkKafkaConsumer;
+import com.netease.arctic.flink.read.LogKafkaConsumer;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSource;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSourceBuilder;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
+import com.netease.arctic.flink.util.Projection;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaDeserializationSchemaWrapper;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
@@ -51,6 +61,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -58,6 +69,7 @@ import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSUMER_CHANGELOG_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
@@ -72,7 +84,7 @@ import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
 /**
  * This is a log source table api, create log queue consumer e.g. {@link LogKafkaSource}
  */
-public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown {
+public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown, SupportsProjectionPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogDynamicSource.class);
   
@@ -86,13 +98,35 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
    * Watermark strategy that is used to generate per-partition watermark.
    */
   protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
-  
+
   /** Data type to configure the formats. */
 
   /**
    * Indices that determine the value fields and the target position in the produced row.
    */
   protected final int[] valueProjection;
+  /**
+   * Field index paths of all fields that must be present in the physically produced data.
+   */
+  protected int[] projectedFields;
+
+  /**
+   * Data type to configure the formats.
+   *
+   * @deprecated since 0.4.1, will be removed in 0.7.0;
+   */
+  @Nullable
+  @Deprecated
+  protected DataType physicalDataType;
+
+  /**
+   * Format for decoding values from Kafka.
+   *
+   * @deprecated since 0.4.1, will be removed in 0.7.0;
+   */
+  @Nullable
+  @Deprecated
+  protected DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
 
   /**
    * The logStore message queue's topics
@@ -144,6 +178,8 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   }
 
   public LogDynamicSource(
+      DataType physicalDataType,
+      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
       int[] valueProjection,
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
@@ -165,9 +201,13 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.properties = properties;
     this.startupMode = toInternal(startupMode);
     this.startupTimestampMillis = startupTimestampMillis;
+    this.physicalDataType = physicalDataType;
+    this.valueDecodingFormat = valueDecodingFormat;
   }
 
-  public LogDynamicSource(
+  LogDynamicSource(
+      DataType physicalDataType,
+      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
       int[] valueProjection,
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
@@ -178,7 +218,8 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       ReadableConfig tableOptions,
       ArcticTable arcticTable,
       boolean logRetractionEnable,
-      Optional<String> consumerChangelogMode) {
+      Optional<String> consumerChangelogMode,
+      int[] projectedFields) {
     this.schema = schema;
     this.tableOptions = tableOptions;
     this.consumerChangelogMode = consumerChangelogMode;
@@ -190,13 +231,16 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.properties = properties;
     this.startupMode = startupMode;
     this.startupTimestampMillis = startupTimestampMillis;
+    this.projectedFields = projectedFields;
+    this.physicalDataType = physicalDataType;
+    this.valueDecodingFormat = valueDecodingFormat;
   }
 
   protected LogKafkaSource createKafkaSource() {
     Schema projectedSchema = schema;
-    if (valueProjection != null) {
+    if (projectedFields != null) {
       final List<Types.NestedField> columns = schema.columns();
-      projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
     }
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
@@ -258,6 +302,78 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     return pulsarSourceBuilder.build();
   }
 
+  /**
+   * Use {@link #createKafkaSource()} instead.
+   *
+   * @deprecated since 0.4.1, will be removed in 0.7.0;
+   */
+  @Deprecated
+  protected FlinkKafkaConsumer<RowData> createKafkaConsumer(DeserializationSchema<RowData> valueDeserialization) {
+    final FlinkKafkaConsumer<RowData> kafkaConsumer;
+
+    final KafkaDeserializationSchemaWrapper<RowData> deserializationSchemaWrapper =
+        new KafkaDeserializationSchemaWrapper<>(valueDeserialization);
+    Schema projectedSchema = schema;
+    if (projectedFields != null) {
+      final List<Types.NestedField> columns = schema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
+    }
+    if (topics != null) {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topics,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    } else {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topicPattern,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    }
+
+    switch (startupMode) {
+      case EARLIEST:
+        kafkaConsumer.setStartFromEarliest();
+        break;
+      case LATEST:
+        kafkaConsumer.setStartFromLatest();
+        break;
+      case GROUP_OFFSETS:
+        kafkaConsumer.setStartFromGroupOffsets();
+        break;
+      case TIMESTAMP:
+        kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
+        break;
+    }
+
+    kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
+
+    if (watermarkStrategy != null) {
+      kafkaConsumer.assignTimestampsAndWatermarks(watermarkStrategy);
+    }
+    return kafkaConsumer;
+  }
+
+  /**
+   * Use {@link #createKafkaSource()} instead.
+   *
+   * @deprecated since 0.4.1, will be removed in 0.7.0;
+   */
+  @Deprecated
+  private FlinkKafkaConsumer<RowData> createKafkaConsumer(ScanContext scanContext) {
+    if (useOldAPI()) {
+      final DeserializationSchema<RowData> valueDeserialization =
+          createDeserialization(scanContext, valueDecodingFormat, valueProjection, null);
+      return createKafkaConsumer(valueDeserialization);
+    }
+    return null;
+  }
+  
   @Override
   public ChangelogMode getChangelogMode() {
     String changeLogMode = consumerChangelogMode.orElse(
@@ -300,6 +416,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
 
   @Override
   public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+    final FlinkKafkaConsumer<RowData> kafkaConsumer = createKafkaConsumer(scanContext);
     final Source<RowData, ?, ?> logSource = buildLogSource();
 
     return new DataStreamScanProvider() {
@@ -307,6 +424,15 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
         if (watermarkStrategy == null) {
           watermarkStrategy = WatermarkStrategy.noWatermarks();
+        }
+
+        if (useOldAPI()) {
+          final TypeInformation<RowData> producedTypeInfo =
+              scanContext.createTypeInformation(Optional.ofNullable(projectedFields)
+                  .map(Projection::of)
+                  .map(p -> p.project(physicalDataType)).orElse(physicalDataType));
+          LOG.info("build deprecated log kafka source");
+          return execEnv.addSource(kafkaConsumer, arcticTable.name(), producedTypeInfo);
         }
         return execEnv.fromSource(
             logSource, watermarkStrategy, "LogStoreSource-" + arcticTable.name());
@@ -319,9 +445,50 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     };
   }
 
+  /**
+   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
+   * {@link LOG_STORE_TYPE} is kafka.
+   */
+  private boolean useOldAPI() {
+    boolean useOldAPI =  CompatibleFlinkPropertyUtil.propertyAsBoolean(
+        arcticTable.properties(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
+    if (useOldAPI) {
+      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
+      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
+        LOG.warn("{} option only take effect for {} = {}.",
+            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @Nullable
+  private DeserializationSchema<RowData> createDeserialization(
+      Context context,
+      @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+      int[] projection,
+      @Nullable String prefix) {
+    if (format == null) {
+      return null;
+    }
+    DataType physicalFormatDataType =
+        DataTypeUtils.projectRow(this.physicalDataType, projection);
+    if (prefix != null) {
+      physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+    }
+    return format.createRuntimeDecoder(context, physicalFormatDataType);
+  }
+
   @Override
   public DynamicTableSource copy() {
     return new LogDynamicSource(
+        this.physicalDataType,
+        this.valueDecodingFormat,
         this.valueProjection,
         this.topics,
         this.topicPattern,
@@ -332,7 +499,8 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         this.tableOptions,
         this.arcticTable,
         this.logRetractionEnable,
-        this.consumerChangelogMode);
+        this.consumerChangelogMode,
+        this.projectedFields);
   }
 
   @Override
@@ -345,4 +513,20 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.watermarkStrategy = watermarkStrategy;
   }
 
+  @Override
+  public boolean supportsNestedProjection() {
+    // TODO: support nested projection
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectFields) {
+    this.projectedFields = new int[projectFields.length];
+    for (int i = 0; i < projectFields.length; i++) {
+      Preconditions.checkArgument(
+          projectFields[i].length == 1,
+          "Don't support nested projection now.");
+      this.projectedFields[i] = projectFields[i][0];
+    }
+  }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -18,41 +18,31 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.read.FlinkKafkaConsumer;
-import com.netease.arctic.flink.read.LogKafkaConsumer;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSource;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSourceBuilder;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
-import com.netease.arctic.flink.util.Projection;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
-import org.apache.flink.streaming.connectors.kafka.internals.KafkaDeserializationSchemaWrapper;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
-import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
-import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
@@ -61,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -69,7 +58,6 @@ import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSUMER_CHANGELOG_MODE;
-import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
@@ -84,7 +72,7 @@ import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
 /**
  * This is a log source table api, create log queue consumer e.g. {@link LogKafkaSource}
  */
-public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown, SupportsProjectionPushDown {
+public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogDynamicSource.class);
   
@@ -98,35 +86,13 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
    * Watermark strategy that is used to generate per-partition watermark.
    */
   protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
-
+  
   /** Data type to configure the formats. */
 
   /**
    * Indices that determine the value fields and the target position in the produced row.
    */
   protected final int[] valueProjection;
-  /**
-   * Field index paths of all fields that must be present in the physically produced data.
-   */
-  protected int[] projectedFields;
-
-  /**
-   * Data type to configure the formats.
-   *
-   * @deprecated since 0.4.1, will be removed in 0.7.0;
-   */
-  @Nullable
-  @Deprecated
-  protected DataType physicalDataType;
-
-  /**
-   * Format for decoding values from Kafka.
-   *
-   * @deprecated since 0.4.1, will be removed in 0.7.0;
-   */
-  @Nullable
-  @Deprecated
-  protected DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
 
   /**
    * The logStore message queue's topics
@@ -178,8 +144,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   }
 
   public LogDynamicSource(
-      DataType physicalDataType,
-      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
       int[] valueProjection,
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
@@ -201,13 +165,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.properties = properties;
     this.startupMode = toInternal(startupMode);
     this.startupTimestampMillis = startupTimestampMillis;
-    this.physicalDataType = physicalDataType;
-    this.valueDecodingFormat = valueDecodingFormat;
   }
 
-  LogDynamicSource(
-      DataType physicalDataType,
-      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+  public LogDynamicSource(
       int[] valueProjection,
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
@@ -218,8 +178,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       ReadableConfig tableOptions,
       ArcticTable arcticTable,
       boolean logRetractionEnable,
-      Optional<String> consumerChangelogMode,
-      int[] projectedFields) {
+      Optional<String> consumerChangelogMode) {
     this.schema = schema;
     this.tableOptions = tableOptions;
     this.consumerChangelogMode = consumerChangelogMode;
@@ -231,16 +190,13 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.properties = properties;
     this.startupMode = startupMode;
     this.startupTimestampMillis = startupTimestampMillis;
-    this.projectedFields = projectedFields;
-    this.physicalDataType = physicalDataType;
-    this.valueDecodingFormat = valueDecodingFormat;
   }
 
   protected LogKafkaSource createKafkaSource() {
     Schema projectedSchema = schema;
-    if (projectedFields != null) {
+    if (valueProjection != null) {
       final List<Types.NestedField> columns = schema.columns();
-      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
+      projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
     }
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
@@ -302,78 +258,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     return pulsarSourceBuilder.build();
   }
 
-  /**
-   * Use {@link #createKafkaSource()} instead.
-   *
-   * @deprecated since 0.4.1, will be removed in 0.7.0;
-   */
-  @Deprecated
-  protected FlinkKafkaConsumer<RowData> createKafkaConsumer(DeserializationSchema<RowData> valueDeserialization) {
-    final FlinkKafkaConsumer<RowData> kafkaConsumer;
-
-    final KafkaDeserializationSchemaWrapper<RowData> deserializationSchemaWrapper =
-        new KafkaDeserializationSchemaWrapper<>(valueDeserialization);
-    Schema projectedSchema = schema;
-    if (projectedFields != null) {
-      final List<Types.NestedField> columns = schema.columns();
-      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
-    }
-    if (topics != null) {
-      kafkaConsumer =
-          new LogKafkaConsumer(
-              topics,
-              deserializationSchemaWrapper,
-              properties,
-              projectedSchema,
-              tableOptions);
-    } else {
-      kafkaConsumer =
-          new LogKafkaConsumer(
-              topicPattern,
-              deserializationSchemaWrapper,
-              properties,
-              projectedSchema,
-              tableOptions);
-    }
-
-    switch (startupMode) {
-      case EARLIEST:
-        kafkaConsumer.setStartFromEarliest();
-        break;
-      case LATEST:
-        kafkaConsumer.setStartFromLatest();
-        break;
-      case GROUP_OFFSETS:
-        kafkaConsumer.setStartFromGroupOffsets();
-        break;
-      case TIMESTAMP:
-        kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
-        break;
-    }
-
-    kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
-
-    if (watermarkStrategy != null) {
-      kafkaConsumer.assignTimestampsAndWatermarks(watermarkStrategy);
-    }
-    return kafkaConsumer;
-  }
-
-  /**
-   * Use {@link #createKafkaSource()} instead.
-   *
-   * @deprecated since 0.4.1, will be removed in 0.7.0;
-   */
-  @Deprecated
-  private FlinkKafkaConsumer<RowData> createKafkaConsumer(ScanContext scanContext) {
-    if (useOldAPI()) {
-      final DeserializationSchema<RowData> valueDeserialization =
-          createDeserialization(scanContext, valueDecodingFormat, valueProjection, null);
-      return createKafkaConsumer(valueDeserialization);
-    }
-    return null;
-  }
-  
   @Override
   public ChangelogMode getChangelogMode() {
     String changeLogMode = consumerChangelogMode.orElse(
@@ -416,7 +300,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
 
   @Override
   public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
-    final FlinkKafkaConsumer<RowData> kafkaConsumer = createKafkaConsumer(scanContext);
     final Source<RowData, ?, ?> logSource = buildLogSource();
 
     return new DataStreamScanProvider() {
@@ -424,15 +307,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
         if (watermarkStrategy == null) {
           watermarkStrategy = WatermarkStrategy.noWatermarks();
-        }
-
-        if (useOldAPI()) {
-          final TypeInformation<RowData> producedTypeInfo =
-              scanContext.createTypeInformation(Optional.ofNullable(projectedFields)
-                  .map(Projection::of)
-                  .map(p -> p.project(physicalDataType)).orElse(physicalDataType));
-          LOG.info("build deprecated log kafka source");
-          return execEnv.addSource(kafkaConsumer, arcticTable.name(), producedTypeInfo);
         }
         return execEnv.fromSource(
             logSource, watermarkStrategy, "LogStoreSource-" + arcticTable.name());
@@ -445,50 +319,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     };
   }
 
-  /**
-   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
-   * {@link LOG_STORE_TYPE} is kafka.
-   */
-  private boolean useOldAPI() {
-    boolean useOldAPI =  CompatibleFlinkPropertyUtil.propertyAsBoolean(
-        arcticTable.properties(),
-        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
-        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
-    if (useOldAPI) {
-      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
-          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
-      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
-        LOG.warn("{} option only take effect for {} = {}.",
-            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
-        return false;
-      }
-      return true;
-    }
-    return false;
-  }
-
-  @Nullable
-  private DeserializationSchema<RowData> createDeserialization(
-      Context context,
-      @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-      int[] projection,
-      @Nullable String prefix) {
-    if (format == null) {
-      return null;
-    }
-    DataType physicalFormatDataType =
-        DataTypeUtils.projectRow(this.physicalDataType, projection);
-    if (prefix != null) {
-      physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-    }
-    return format.createRuntimeDecoder(context, physicalFormatDataType);
-  }
-
   @Override
   public DynamicTableSource copy() {
     return new LogDynamicSource(
-        this.physicalDataType,
-        this.valueDecodingFormat,
         this.valueProjection,
         this.topics,
         this.topicPattern,
@@ -499,8 +332,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         this.tableOptions,
         this.arcticTable,
         this.logRetractionEnable,
-        this.consumerChangelogMode,
-        this.projectedFields);
+        this.consumerChangelogMode);
   }
 
   @Override
@@ -513,20 +345,4 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.watermarkStrategy = watermarkStrategy;
   }
 
-  @Override
-  public boolean supportsNestedProjection() {
-    // TODO: support nested projection
-    return false;
-  }
-
-  @Override
-  public void applyProjection(int[][] projectFields) {
-    this.projectedFields = new int[projectFields.length];
-    for (int i = 0; i < projectFields.length; i++) {
-      Preconditions.checkArgument(
-          projectFields[i].length == 1,
-          "Don't support nested projection now.");
-      this.projectedFields[i] = projectFields[i][0];
-    }
-  }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -92,6 +92,13 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .defaultValue(false)
           .withDescription("Flag hidden kafka read retraction enable or not.");
 
+  public static final ConfigOption<Boolean> ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE =
+      ConfigOptions.key("log-store.kafka.compatible.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+              " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
+
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =
       ConfigOptions.key("log.consumer.changelog.modes")
           .stringType()

--- a/site/docs/ch/flink/flink-dml.md
+++ b/site/docs/ch/flink/flink-dml.md
@@ -92,6 +92,7 @@ SELECT * FROM test_table /*+ OPTIONS('arctic.read.mode'='log') */;
 |properties.group.id| (none) |String|Logstore 是 kafka 并且是查询时必填，否则可不填| 读取 Kafka Topic 时使用的 group id|
 |properties.pulsar.admin.adminUrl| (none) |String|Logstore 是 pulsar 时必填，否则可不填| Pulsar admin 的 HTTP URL，如：http://my-broker.example.com:8080|
 |properties.*| (none) |String|否| Logstore的参数。<br><br>对于 Logstore 为 Kafka ('log-store.type'='kafka' 默认值)时，Kafka Consumer 支持的其他所有参数都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.batch.size'='16384'`，<br>完整的参数信息可以参考 [Kafka官方手册](https://kafka.apache.org/documentation/#consumerconfigs); <br><br>对于 Logstore 为 Pulsar ('log-store.type'='pulsar')时，Pulsar 支持的相关配置都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.pulsar.client.requestTimeoutMs'='60000'`，<br>完整的参数信息可以参考 [Flink-Pulsar-Connector文档](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/datastream/pulsar)|
+|log-store.kafka.compatible.enabled| false | Boolean | 否 | 兼容 Logstore Kafka 废弃的 API。当 Flink 任务（使用 >= 0.4.1 Arctic 版本）需要从低于此版本的状态恢复启动时，必须将该参数设为 true。该参数将于 0.7.0 版本删除。
 
 **注意事项**
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

*(For example:)*
  - *Add the 'scan.startup.mode' configuration to the ArcticScanContext in the flink modules*
  - *The flink 1.12 and 1.14 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
